### PR TITLE
Add FastAPI pdf2htmlEX conversion microservice

### DIFF
--- a/pdf2htmlx-service/Dockerfile
+++ b/pdf2htmlx-service/Dockerfile
@@ -1,0 +1,14 @@
+FROM bwits/pdf2htmlex:alpine
+
+RUN apk add --no-cache python3 py3-pip
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY app.py ./
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["sh", "-c", "uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/pdf2htmlx-service/README.md
+++ b/pdf2htmlx-service/README.md
@@ -1,0 +1,98 @@
+# pdf2htmlx-service
+
+Micro-service FastAPI prêt pour la production convertissant des documents PDF en HTML fidèle grâce à [pdf2htmlEX](https://github.com/coolwanglu/pdf2htmlEX). Le service enveloppe l'outil en ligne de commande avec des paramètres optimisés pour l'intégration web (`--split-pages 0 --embed-css 1 --embed-image 1 --embed-font 1 --process-outline 1 --optimize-text 1`).
+
+## Fonctionnalités
+
+- API REST avec FastAPI (Uvicorn) exposant :
+  - `GET /health` : vérification de l'état.
+  - `POST /pdf2html` : conversion via PDF encodé en base64 ou accessible par URL HTTP/HTTPS.
+- Gestion des erreurs explicites (400 en cas de payload invalide, 504 en cas de dépassement de temps).
+- Nettoyage automatique des fichiers temporaires.
+- Image Docker légère basée sur `bwits/pdf2htmlex:alpine` avec Python 3.11.
+
+## Prérequis
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) pour un usage local **ou**
+- Un compte [Render](https://render.com/) pour le déploiement managé.
+
+## Lancement local (Docker)
+
+```bash
+docker build -t pdf2htmlx ./pdf2htmlx-service
+
+docker run --rm -p 8080:8080 pdf2htmlx
+```
+
+Tester rapidement la conversion (nécessite `curl` et `jq`) :
+
+```bash
+curl -X POST http://localhost:8080/pdf2html \
+     -H "Content-Type: application/json" \
+     -d '{"pdf_url":"https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf","request_id":"demo-1"}' \
+     | jq -r .html > out.html
+```
+
+Ouvrez ensuite `out.html` dans votre navigateur pour vérifier le rendu.
+
+## Déploiement sur Render
+
+1. Poussez ce répertoire dans un dépôt Git public ou privé.
+2. Connectez votre dépôt à Render et créez un nouveau service **Web**.
+3. Render détecte automatiquement le `Dockerfile` à la racine du répertoire (dans `pdf2htmlx-service/`).
+4. Aucun réglage de port n'est nécessaire : le process écoute `0.0.0.0:${PORT:-8080}` comme requis par Render.
+
+Le fichier [`render.yaml`](render.yaml) fournit un blueprint minimal pour l'Infrastructure as Code Render.
+
+## API
+
+### Requête
+
+`POST /pdf2html`
+
+```json
+{
+  "request_id": "demo-1",
+  "filename": "rapport.pdf",
+  "pdf_b64": "...",
+  "pdf_url": "https://exemple.com/doc.pdf"
+}
+```
+
+- `pdf_b64` **ou** `pdf_url` est requis. Si les deux sont fournis, `pdf_b64` est prioritaire.
+- `filename` est facultatif et utilisé uniquement dans la réponse pour référence.
+
+### Réponse
+
+```json
+{
+  "request_id": "demo-1",
+  "filename": "rapport.pdf",
+  "metrics": {
+    "pages": 3,
+    "html_bytes": 128764
+  },
+  "html": "<!DOCTYPE html>..."
+}
+```
+
+### Codes d'état principaux
+
+- `200 OK` : conversion réussie.
+- `400 Bad Request` : base64 invalide ou URL inaccessible.
+- `504 Gateway Timeout` : conversion dépassant 180 secondes.
+- `500 Internal Server Error` : échec `pdf2htmlEX` ou sortie manquante.
+
+## Notes supplémentaires
+
+- Les sorties HTML peuvent être volumineuses ; activez la compression HTTP côté reverse proxy/plateforme si nécessaire.
+- Les indicateurs `pdf2htmlEX` sont documentés dans la [documentation officielle](https://github.com/coolwanglu/pdf2htmlEX/wiki/pdf2htmlEX-Command-Line-Options).
+- Les logs applicatifs utilisent le logger `uvicorn.error` pour s'aligner sur la stack Uvicorn.
+
+## Fichiers fournis
+
+- `app.py` : application FastAPI.
+- `requirements.txt` : dépendances Python.
+- `Dockerfile` : build de l'image Docker.
+- `render.yaml` : blueprint Render.
+- `README.md` : ce guide.

--- a/pdf2htmlx-service/app.py
+++ b/pdf2htmlx-service/app.py
@@ -1,0 +1,204 @@
+"""FastAPI microservice to convert PDFs to HTML using pdf2htmlEX."""
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import re
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Dict, Optional, Tuple
+
+import requests
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, HttpUrl, field_validator, model_validator
+
+logger = logging.getLogger("uvicorn.error")
+
+DEFAULT_FILENAME = "document.pdf"
+HTML_OUTPUT_NAME = "out.html"
+PDF2HTMLEX_TIMEOUT = 180
+PDF_DOWNLOAD_TIMEOUT = 60
+PDF2HTMLEX_CMD = [
+    "pdf2htmlEX",
+    "--split-pages",
+    "0",
+    "--embed-css",
+    "1",
+    "--embed-image",
+    "1",
+    "--embed-font",
+    "1",
+    "--process-outline",
+    "1",
+    "--optimize-text",
+    "1",
+]
+
+
+class ConversionRequest(BaseModel):
+    """Incoming payload for PDF to HTML conversion."""
+
+    request_id: Optional[str] = None
+    filename: Optional[str] = None
+    pdf_b64: Optional[str] = None
+    pdf_url: Optional[HttpUrl] = None
+
+    @model_validator(mode="after")
+    def ensure_source_present(self) -> "ConversionRequest":
+        if not self.pdf_b64 and not self.pdf_url:
+            raise ValueError("One of pdf_b64 or pdf_url must be provided.")
+        return self
+
+    @field_validator("pdf_b64")
+    @classmethod
+    def strip_whitespace(cls, value: Optional[str]) -> Optional[str]:
+        return value.strip() if isinstance(value, str) else value
+
+
+class ConversionResponse(BaseModel):
+    request_id: Optional[str]
+    filename: str
+    metrics: Dict[str, int]
+    html: str
+
+
+app = FastAPI(title="pdf2htmlEX microservice", version="1.0.0")
+
+
+def _decode_pdf_b64(encoded: str) -> bytes:
+    try:
+        return base64.b64decode(encoded, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid base64 payload provided for pdf_b64.",
+        ) from exc
+
+
+def _fetch_pdf_url(url: HttpUrl) -> Tuple[bytes, Optional[str]]:
+    try:
+        response = requests.get(str(url), timeout=PDF_DOWNLOAD_TIMEOUT)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        logger.warning("Failed to fetch PDF from URL %s: %s", url, exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unable to download PDF from the provided URL.",
+        ) from exc
+
+    filename = Path(response.url).name or None
+    return response.content, filename
+
+
+def _load_pdf_bytes(payload: ConversionRequest) -> Tuple[bytes, Optional[str]]:
+    if payload.pdf_b64:
+        return _decode_pdf_b64(payload.pdf_b64), None
+    if payload.pdf_url:
+        return _fetch_pdf_url(payload.pdf_url)
+    # Should be unreachable due to validator, but keeps type-checkers happy.
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="No PDF source provided.",
+    )
+
+
+def _truncate_message(message: str, limit: int = 4000) -> str:
+    if len(message) <= limit:
+        return message
+    return message[: limit - 3] + "..."
+
+
+def _extract_page_count(*outputs: str) -> Optional[int]:
+    page_pattern = re.compile(r"pages?\s*:?\s*(\d+)", re.IGNORECASE)
+    for output in outputs:
+        if not output:
+            continue
+        match = page_pattern.search(output)
+        if match:
+            try:
+                return int(match.group(1))
+            except ValueError:
+                continue
+    return None
+
+
+@app.get("/health")
+def healthcheck() -> dict:
+    """Simple health endpoint used by Render and other orchestrators."""
+    return {"ok": True}
+
+
+@app.post("/pdf2html", response_model=ConversionResponse)
+def convert_pdf(payload: ConversionRequest) -> ConversionResponse:
+    pdf_bytes, inferred_filename = _load_pdf_bytes(payload)
+    target_filename = payload.filename or inferred_filename or DEFAULT_FILENAME
+
+    with TemporaryDirectory(prefix="pdf2htmlx-") as tmpdir:
+        tmp_path = Path(tmpdir)
+        input_pdf = tmp_path / "input.pdf"
+        output_html = tmp_path / HTML_OUTPUT_NAME
+
+        input_pdf.write_bytes(pdf_bytes)
+
+        command = [
+            *PDF2HTMLEX_CMD,
+            "--dest-dir",
+            str(tmp_path),
+            str(input_pdf),
+            HTML_OUTPUT_NAME,
+        ]
+
+        logger.info("Running pdf2htmlEX for request_id=%s", payload.request_id)
+        try:
+            completed = subprocess.run(  # noqa: S603
+                command,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=PDF2HTMLEX_TIMEOUT,
+                text=True,
+            )
+        except subprocess.TimeoutExpired as exc:
+            logger.error(
+                "pdf2htmlEX timed out after %s seconds for request_id=%s",
+                PDF2HTMLEX_TIMEOUT,
+                payload.request_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="Conversion timed out.",
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr_msg = _truncate_message(exc.stderr or "Conversion failed without error output.")
+            logger.error("pdf2htmlEX failed: %s", stderr_msg)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"pdf2htmlEX failed: {stderr_msg}",
+            ) from exc
+
+        if not output_html.exists():
+            logger.error("Expected HTML output not produced by pdf2htmlEX.")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="pdf2htmlEX did not produce an HTML file.",
+            )
+
+        html_content = output_html.read_text(encoding="utf-8")
+        html_bytes = len(html_content.encode("utf-8"))
+        pages = _extract_page_count(completed.stdout, completed.stderr)
+
+    metrics: Dict[str, int] = {"html_bytes": html_bytes}
+    if pages is not None:
+        metrics["pages"] = pages
+
+    return ConversionResponse(
+        request_id=payload.request_id,
+        filename=target_filename,
+        metrics=metrics,
+        html=html_content,
+    )
+
+
+__all__ = ["app"]

--- a/pdf2htmlx-service/render.yaml
+++ b/pdf2htmlx-service/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: pdf2htmlx-service
+    env: docker
+    plan: free
+    autoDeploy: true
+    healthCheckPath: /health

--- a/pdf2htmlx-service/requirements.txt
+++ b/pdf2htmlx-service/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+pydantic>=2.7
+requests==2.32.3


### PR DESCRIPTION
## Summary
- add a FastAPI application that runs pdf2htmlEX with strict validation, metrics, and error handling
- document container usage and deployment steps alongside Render blueprint
- provide Docker-based packaging, dependency manifest, and runtime configuration

## Testing
- python3 -m compileall pdf2htmlx-service/app.py

------
https://chatgpt.com/codex/tasks/task_e_68e3deacdc04832c8f5609620f539ce7