### PR TITLE
Refactor FastAPI service for Pydantic v2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,47 @@
-# pdf2htmlex-service
+# pdf2htmlEX (light)
 
-`pdf2htmlex-service` is a FastAPI microservice that wraps [`pdf2htmlEX`](https://github.com/pdf2htmlEX/pdf2htmlEX) to convert PDFs into self-contained HTML. It is designed for deployment on Render.com as a Docker web service.
+Service FastAPI minimal pour convertir un PDF en HTML “texte” par page.
 
 ## Endpoints
+
 - `GET /health` → `{ "ok": true }`
-- `POST /pdf2html`
-  ```json
-  {
-    "request_id": "demo-1",
-    "filename": "sample.pdf",
-    "pdf_b64": null,
-    "pdf_url": "https://example.com/sample.pdf",
-    "options": {
-      "embed": "all",
-      "zoom": 1.0,
-      "page_from": null,
-      "page_to": null,
-      "timeout_sec": 120,
-      "returnZipB64": false
-    }
+- `POST /pdf2htmlex`
+
+### Body JSON attendu
+
+```json
+{
+  "request_id": "2025-10-06T14:58:22.526Z",
+  "filename": "upload.pdf",
+  "pdf_b64": "JVBERi0xLjc... (optionnel)",
+  "pdf_url": "https://exemple.com/sample.pdf (optionnel, si pas de pdf_b64)",
+  "options": {
+    "ocr": true,
+    "mode": "both",
+    "injectLinks": true,
+    "promoteHeadings": true,
+    "graphEngine": "heuristic",
+    "locale": "fr-FR",
+    "returnZipB64": true
   }
-  ```
+}
 
-Responses include the conversion metrics and either the generated HTML or a base64 ZIP archive when `returnZipB64` is enabled.
+Réponse JSON
+{
+  "request_id": "2025-10-06T14:58:22.526Z",
+  "filename": "upload.pdf",
+  "metrics": { "pages": 5 },
+  "html_semantic": "<html>...<section data-page='1'><pre>...</pre></section>...</html>"
+}
 
-## Running locally with Docker
-```bash
-docker build -t pdf2htmlex-service .
-docker run -e PORT=10000 -p 10000:10000 pdf2htmlex-service
-```
-Then visit http://localhost:10000/health or http://localhost:10000/docs.
+Lancer en local
+python -m venv .venv && . .venv/bin/activate
+pip install --upgrade pip setuptools wheel
+pip install -r requirements.txt
+uvicorn app:app --reload
 
-## Deploying on Render
-1. Push this repository to your own GitHub/GitLab account.
-2. In Render, click **New** → **Web Service**.
-3. Choose **Docker** and point Render to your repository.
-4. Render will detect `render.yaml` and build using the included `Dockerfile`.
-5. Deploy. Render requires the application to bind to `0.0.0.0` and the port supplied in the `PORT` environment variable—this service already does that.
+Déploiement Render
 
-Render Python version is set via `PYTHON_VERSION` or `.python-version`. See the [Render documentation](https://render.com/docs/python-version) for details.
+Start: uvicorn app:app --host 0.0.0.0 --port $PORT
 
-## Example `curl`
-```bash
-BASE="https://pdf2htmlex.onrender.com"
-curl -X POST "$BASE/pdf2html" \
-  -H "Content-Type: application/json" \
-  -d '{"request_id":"demo-1","filename":"sample.pdf","pdf_url":"https://example.com/sample.pdf","options":{"embed":"all","returnZipB64":true}}'
-```
-
-`/health` returns `{ "ok": true }` and can be used by Render's health checks.
-
-## Testing
-```bash
-pip install -r requirements.txt pytest
-pytest
-```
-
-The pdf conversion test is skipped automatically if the `pdf2htmlEX` binary is not available (for example, outside the Docker image).
+Variable d’environnement : PYTHON_VERSION=3.11.9

--- a/app.py
+++ b/app.py
@@ -1,236 +1,130 @@
+from __future__ import annotations
+
 import base64
-import binascii
-import io
+import html
 import logging
-import os
-import shutil
-import subprocess
-import tempfile
-import time
-import uuid
-import zipfile
-from pathlib import Path
+from io import BytesIO
 from typing import Literal, Optional
 
-import requests
-from fastapi import FastAPI, HTTPException, Request, status
-from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field, root_validator
+import httpx
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, HttpUrl, field_validator, model_validator
 from pypdf import PdfReader
 
-logger = logging.getLogger("uvicorn.error")
+log = logging.getLogger("uvicorn.error")
 
-MAX_PDF_BYTES = 20 * 1024 * 1024  # 20 MB
-PDF_DOWNLOAD_TIMEOUT = 60
+app = FastAPI(title="pdf2htmlEX (light)")
+
+# CORS (ouvrir/resserrer selon besoin)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 class PdfOptions(BaseModel):
-    embed: Literal["all", "none", "css", "image", "font"] = "all"
-    zoom: float = Field(1.0, gt=0)
-    page_from: Optional[int] = Field(default=None, ge=1)
-    page_to: Optional[int] = Field(default=None, ge=1)
-    timeout_sec: int = Field(120, ge=1, le=900)
-    returnZipB64: bool = False
+    # Options conservées pour compatibilité n8n, certaines non utilisées ici
+    ocr: bool = True
+    mode: Literal["text", "both"] = "both"
+    injectLinks: bool = True
+    promoteHeadings: bool = True
+    graphEngine: Literal["heuristic", "none"] = "heuristic"
+    locale: str = "fr-FR"
+    returnZipB64: bool = True
 
-    @root_validator
-    def validate_page_range(cls, values):
-        start = values.get("page_from")
-        end = values.get("page_to")
-        if start and end and start > end:
-            raise ValueError("page_from must be <= page_to")
-        return values
+    @field_validator("locale")
+    @classmethod
+    def _normalize_locale(cls, v: str) -> str:
+        return v or "fr-FR"
+
+    @model_validator(mode="after")
+    def _coherence(self) -> "PdfOptions":
+        if self.mode not in {"text", "both"}:
+            raise ValueError("mode must be 'text' or 'both'")
+        return self
 
 
 class Pdf2HtmlIn(BaseModel):
     request_id: Optional[str] = None
     filename: Optional[str] = None
     pdf_b64: Optional[str] = None
-    pdf_url: Optional[str] = None
-    options: PdfOptions = Field(default_factory=PdfOptions)
+    pdf_url: Optional[HttpUrl] = None
+    options: Optional[PdfOptions] = PdfOptions()
 
-    @root_validator
-    def validate_source(cls, values):
-        pdf_b64 = values.get("pdf_b64")
-        pdf_url = values.get("pdf_url")
-        if not pdf_b64 and not pdf_url:
-            raise ValueError("At least one of pdf_b64 or pdf_url must be provided")
-        return values
-
-app = FastAPI(title="pdf2htmlex-service")
+    @model_validator(mode="after")
+    def _one_source(self) -> "Pdf2HtmlIn":
+        if not self.pdf_b64 and not self.pdf_url:
+            raise ValueError("Provide either pdf_b64 or pdf_url")
+        return self
 
 
-def _decode_pdf_from_b64(data: str) -> bytes:
-    try:
-        return base64.b64decode(data, validate=True)
-    except (ValueError, binascii.Error) as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid base64 payload: {exc}")
-    except Exception as exc:  # pragma: no cover - defensive
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid base64 payload: {exc}")
-
-
-def _download_pdf(url: str) -> bytes:
-    if not url.lower().startswith(("http://", "https://")):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="pdf_url must start with http:// or https://")
-    try:
-        response = requests.get(url, timeout=PDF_DOWNLOAD_TIMEOUT)
-        response.raise_for_status()
-    except requests.exceptions.RequestException as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Failed to download PDF: {exc}")
-    return response.content
-
-
-def _write_pdf_to_disk(pdf_bytes: bytes, destination: Path) -> None:
-    destination.write_bytes(pdf_bytes)
-
-
-def _build_command(options: PdfOptions, input_pdf: Path, output_html: Path) -> list[str]:
-    embed_map = {
-        "all": {"css": "1", "image": "1", "font": "1"},
-        "none": {"css": "0", "image": "0", "font": "0"},
-        "css": {"css": "1", "image": "0", "font": "0"},
-        "image": {"css": "0", "image": "1", "font": "0"},
-        "font": {"css": "0", "image": "0", "font": "1"},
-    }
-    embed_flags = embed_map[options.embed]
-
-    command = [
-        "pdf2htmlEX",
-        "--embed-css",
-        embed_flags["css"],
-        "--embed-image",
-        embed_flags["image"],
-        "--embed-font",
-        embed_flags["font"],
-        "--zoom",
-        str(options.zoom),
-    ]
-
-    if options.page_from is not None:
-        command.extend(["--first-page", str(options.page_from)])
-    if options.page_to is not None:
-        command.extend(["--last-page", str(options.page_to)])
-
-    command.extend([str(input_pdf), str(output_html)])
-    return command
-
-
-@app.exception_handler(RequestValidationError)
-async def validation_exception_handler(request: Request, exc: RequestValidationError):
-    body = (await request.body()).decode("utf-8", errors="ignore")
-    logger.error("422 validation error request_body=%s errors=%s", body[:1000], exc.errors())
-    return JSONResponse(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content={"detail": exc.errors()})
+class Pdf2HtmlOut(BaseModel):
+    request_id: Optional[str] = None
+    filename: Optional[str] = None
+    html_semantic: str
+    metrics: dict
 
 
 @app.get("/health")
-def health() -> dict[str, bool]:
+def health() -> dict:
     return {"ok": True}
 
 
-@app.post("/pdf2html")
-@app.post("/pdf2htmlex")
-def pdf2html(payload: Pdf2HtmlIn):
-    request_id = payload.request_id or str(uuid.uuid4())
-    start_ts = time.perf_counter()
-
+def _load_pdf_bytes(payload: Pdf2HtmlIn) -> bytes:
     if payload.pdf_b64:
-        pdf_bytes = _decode_pdf_from_b64(payload.pdf_b64)
-        source = "b64"
-    else:
-        assert payload.pdf_url  # for type checker
-        pdf_url = payload.pdf_url.strip()
-        if not pdf_url:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="pdf_url must be non-empty")
-        pdf_bytes = _download_pdf(pdf_url)
-        source = "url"
-
-    if len(pdf_bytes) > MAX_PDF_BYTES:
-        raise HTTPException(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail="PDF exceeds 20MB limit")
-
-    try:
-        pdf_reader = PdfReader(io.BytesIO(pdf_bytes))
-        page_count = len(pdf_reader.pages)
-    except Exception:
-        page_count = 0
-
-    tmp_dir = Path(tempfile.mkdtemp(prefix="pdf2htmlex_"))
-    pdf_path = tmp_dir / "input.pdf"
-    html_path = tmp_dir / "output.html"
-
-    try:
-        _write_pdf_to_disk(pdf_bytes, pdf_path)
-        command = _build_command(payload.options, pdf_path, html_path)
-
         try:
-            process = subprocess.run(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                timeout=payload.options.timeout_sec,
-                check=False,
-            )
-        except subprocess.TimeoutExpired:
-            raise HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail="pdf2htmlEX timed out")
+            return base64.b64decode(payload.pdf_b64, validate=True)
+        except Exception as e:  # noqa: BLE001
+            raise HTTPException(status_code=400, detail=f"Invalid base64: {e}")
+    assert payload.pdf_url is not None
+    try:
+        with httpx.Client(timeout=httpx.Timeout(30.0)) as client:
+            r = client.get(str(payload.pdf_url))
+            r.raise_for_status()
+            return r.content
+    except httpx.HTTPError as e:
+        log.exception("Failed to download pdf from %s", payload.pdf_url)
+        raise HTTPException(status_code=400, detail=f"Failed to download pdf_url: {e}")
 
-        if process.returncode != 0:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail={
-                    "message": "pdf2htmlEX failed",
-                    "exit_code": process.returncode,
-                    "stderr": process.stderr,
-                },
-            )
 
-        if not html_path.exists():
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="HTML output not produced")
+def _pdf_to_html(blob: bytes, opts: PdfOptions) -> tuple[str, int]:
+    """Extraction texte par page et encapsulation simple en HTML."""
+    reader = PdfReader(BytesIO(blob))
+    html_parts = [
+        "<html><head><meta charset='utf-8'>"
+        "<style>pre{white-space:pre-wrap;word-break:break-word}</style>"
+        "</head><body>"
+    ]
+    for i, page in enumerate(reader.pages, start=1):
+        try:
+            text = page.extract_text() or ""
+        except Exception:  # noqa: BLE001
+            log.exception("extract_text failed on page %s", i)
+            text = ""
+        html_parts.append(f"<section data-page='{i}'><pre>{html.escape(text)}</pre></section>")
+    html_parts.append("</body></html>")
+    html_doc = "\n".join(html_parts)
+    return html_doc, len(reader.pages)
 
-        if payload.options.returnZipB64:
-            zip_buffer = io.BytesIO()
-            with zipfile.ZipFile(zip_buffer, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-                for path in tmp_dir.rglob("*"):
-                    if path.is_file() and path != pdf_path:
-                        zf.write(path, arcname=path.relative_to(tmp_dir))
-            html_output_bytes = zip_buffer.getvalue()
-            response_payload = {
-                "html_zip_b64": base64.b64encode(html_output_bytes).decode("utf-8"),
-                "html_semantic": None,
-            }
-            return_size = len(html_output_bytes)
-        else:
-            html_output_bytes = html_path.read_bytes()
-            html_text = html_output_bytes.decode("utf-8", errors="ignore")
-            response_payload = {
-                "html": html_text,
-                "html_semantic": html_text,
-            }
-            return_size = len(html_output_bytes)
 
-    finally:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-
-    elapsed_ms = int((time.perf_counter() - start_ts) * 1000)
-
-    logger.info(
-        "request_id=%s source=%s bytes_in=%s pages=%s elapsed_ms=%s bytes_out=%s",
-        request_id,
-        source,
-        len(pdf_bytes),
-        page_count,
-        elapsed_ms,
-        return_size,
+@app.post("/pdf2htmlex", response_model=Pdf2HtmlOut)
+def pdf2htmlex(payload: Pdf2HtmlIn) -> Pdf2HtmlOut:
+    blob = _load_pdf_bytes(payload)
+    html_doc, pages = _pdf_to_html(blob, payload.options or PdfOptions())
+    return Pdf2HtmlOut(
+        request_id=payload.request_id,
+        filename=payload.filename or "upload.pdf",
+        html_semantic=html_doc,
+        metrics={"pages": pages},
     )
 
-    response = {
-        "request_id": request_id,
-        "metrics": {"pages": page_count, "elapsed_ms": elapsed_ms},
-    }
-    response.update(response_payload)
-    return response
 
+# Optionnel: racine
+@app.get("/")
+def root() -> dict:
+    return {"service": "pdf2htmlEX (light)", "endpoints": ["/health", "/pdf2htmlex"]}
 
-if __name__ == "__main__":
-    import uvicorn
-
-    uvicorn.run("app:app", host="0.0.0.0", port=int(os.getenv("PORT", "10000")), reload=False)

--- a/render.yaml
+++ b/render.yaml
@@ -1,9 +1,10 @@
 services:
   - type: web
     name: pdf2htmlex
-    env: docker
+    env: python
     plan: free
-    region: frankfurt
-    autoDeploy: true
-    healthCheckPath: /health
-    dockerfilePath: Dockerfile
+    buildCommand: pip install --upgrade pip setuptools wheel && pip install --no-cache-dir -r requirements.txt
+    startCommand: uvicorn app:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.11.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 fastapi==0.115.0
 uvicorn==0.30.6
-requests==2.32.3
-pydantic>=2.8,<3
+pydantic==2.11.10
 pypdf==4.3.1
 httpx==0.27.2


### PR DESCRIPTION
## Summary
- replace the legacy pdf2htmlEX endpoints with a lightweight FastAPI service that extracts PDF text per page and returns semantic HTML
- update the dependency stack to FastAPI and Pydantic v2 and refresh the Render deployment configuration
- document the API contract and deployment steps in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e438af3a18832cb86f70e707869197